### PR TITLE
https://github.com/librestack/librecast/issues/39#event-4626402391

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 #
 # this file is part of LIBRESTACK
 #

--- a/modules/Makefile
+++ b/modules/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 # Copyright (c) 2020 Brett Sheffield <bacs@librecast.net>
 SHELL = /bin/sh
 .SUFFIXES:

--- a/modules/http.c
+++ b/modules/http.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * http.c
  *

--- a/modules/http.h
+++ b/modules/http.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * http.h
  *

--- a/modules/librecast.c
+++ b/modules/librecast.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * librecast.c
  *

--- a/modules/librecast.h
+++ b/modules/librecast.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * librecast.h
  *

--- a/modules/websocket.c
+++ b/modules/websocket.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * websocket.c
  *

--- a/modules/websocket.h
+++ b/modules/websocket.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * websocket.h
  *

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 #
 # this file is part of LIBRESTACK
 #

--- a/src/config.c
+++ b/src/config.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * config.c
  *

--- a/src/config.h
+++ b/src/config.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * config.h
  *

--- a/src/db.c
+++ b/src/db.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * db.c
  *

--- a/src/db.h
+++ b/src/db.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * db.h
  *

--- a/src/err.c
+++ b/src/err.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later 
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only 
  *
  * err.c - error handling function definitions
  *

--- a/src/err.h
+++ b/src/err.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * err.c
  *

--- a/src/handler.c
+++ b/src/handler.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * handler.c
  *

--- a/src/handler.h
+++ b/src/handler.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * handler.h
  *

--- a/src/iov.c
+++ b/src/iov.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * iov.c
  *

--- a/src/iov.h
+++ b/src/iov.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * iov.h
  *

--- a/src/log.c
+++ b/src/log.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * log.c
  *

--- a/src/log.h
+++ b/src/log.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * log.h
  *

--- a/src/lsd.c
+++ b/src/lsd.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * lsd.c
  *

--- a/src/lsd.h
+++ b/src/lsd.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * lsd.h
  *

--- a/src/misc.c
+++ b/src/misc.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include <stdarg.h>

--- a/src/misc.h
+++ b/src/misc.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #ifndef _LIBRESTACK_MISC_H__

--- a/src/server.c
+++ b/src/server.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * server.c
  *

--- a/src/server.h
+++ b/src/server.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * server.h
  *

--- a/src/str.c
+++ b/src/str.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * str.c
  *

--- a/src/str.h
+++ b/src/str.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
  *
  * str.h
  *

--- a/src/wire.h
+++ b/src/wire.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #ifndef _LSDM_WIRE_H

--- a/test/0000-0000.c
+++ b/test/0000-0000.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/0000-0001.c
+++ b/test/0000-0001.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/0000-0002.c
+++ b/test/0000-0002.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/0000-0003.c
+++ b/test/0000-0003.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/0000-0004.c
+++ b/test/0000-0004.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/0000-0005.c
+++ b/test/0000-0005.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/0000-0006.c
+++ b/test/0000-0006.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only
 # Copyright (c) 2020 Brett Sheffield <bacs@librecast.net>
 
 SHELL := /bin/bash

--- a/test/test.c
+++ b/test/test.c
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include "test.h"

--- a/test/test.h
+++ b/test/test.h
@@ -1,4 +1,4 @@
-/* SPDX-License-Identifier: GPL-3.0-or-later */
+/* SPDX-License-Identifier: GPL-2.0-only OR GPL-3.0-only */
 /* Copyright (c) 2020 Brett Sheffield <bacs@librecast.net> */
 
 #include <stdio.h>


### PR DESCRIPTION
As the Free Software Foundation has decided to reinstate Richard Stallman, The Librecast project no longer feels that the FSF is an appropriate steward of Free Software and wish to ensure that any future versions of the GPL do not automatically apply to Librecast.

Therefore we have decided to drop the "or later" part of the GPL licence. We have also decided to dual licence Librecast and add GPLv2.

We still believe in the GPL and copyleft, however the Free Software Movement is more than The Free Software Foundation. Like any other project we have benefited from the four freedoms and we believe in them. We are also free to demonstrate our current lack of trust in the board of the FSF.

